### PR TITLE
enable no-outlet-outside-routes lint rule again

### DIFF
--- a/examples/components/app/templates/application.hbs
+++ b/examples/components/app/templates/application.hbs
@@ -1,4 +1,3 @@
-{{! template-lint-disable no-outlet-outside-routes }}
 <nav>
   <ul>
     <li>


### PR DESCRIPTION
This enables the `no-outlet-outside-routes` again that we had to disable because of a bug in ember-template-lint.

closes #85 