### PR TITLE
Update routing example

### DIFF
--- a/examples/routing/.editorconfig
+++ b/examples/routing/.editorconfig
@@ -4,7 +4,6 @@
 
 root = true
 
-
 [*]
 end_of_line = lf
 charset = utf-8

--- a/examples/routing/.eslintrc.js
+++ b/examples/routing/.eslintrc.js
@@ -1,8 +1,14 @@
+'use strict';
+
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module'
+    sourceType: 'module',
+    ecmaFeatures: {
+      legacyDecorators: true
+    }
   },
   plugins: [
     'ember'
@@ -14,8 +20,7 @@ module.exports = {
   env: {
     browser: true
   },
-  rules: {
-  },
+  rules: {},
   overrides: [
     // node files
     {
@@ -30,21 +35,19 @@ module.exports = {
         'server/**/*.js'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,
         node: true
       },
       plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-
+      extends: ['plugin:node/recommended'],
+      rules: {
         // this can be removed once the following is fixed
         // https://github.com/mysticatea/eslint-plugin-node/issues/77
         'node/no-unpublished-require': 'off'
-      })
+      }
     }
   ]
 };

--- a/examples/routing/.template-lintrc.js
+++ b/examples/routing/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended'
+  extends: 'octane'
 };

--- a/examples/routing/README.md
+++ b/examples/routing/README.md
@@ -8,7 +8,8 @@ A short introduction of this app could easily go here.
 You will need the following things properly installed on your computer.
 
 * [Git](https://git-scm.com/)
-* [Node.js](https://nodejs.org/) (with npm)
+* [Node.js](https://nodejs.org/)
+* [Yarn](https://yarnpkg.com/)
 * [Ember CLI](https://ember-cli.com/)
 * [Google Chrome](https://google.com/chrome/)
 
@@ -16,7 +17,7 @@ You will need the following things properly installed on your computer.
 
 * `git clone <repository-url>` this repository
 * `cd routing`
-* `npm install`
+* `yarn install`
 
 ## Running / Development
 
@@ -35,9 +36,9 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 ### Linting
 
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
+* `yarn lint:hbs`
+* `yarn lint:js`
+* `yarn lint:js --fix`
 
 ### Building
 

--- a/examples/routing/app/app.js
+++ b/examples/routing/app/app.js
@@ -1,14 +1,12 @@
 import Application from '@ember/application';
-import Resolver from './resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import config from 'routing/config/environment';
 
-const App = Application.extend({
-  modulePrefix: config.modulePrefix,
-  podModulePrefix: config.podModulePrefix,
-  Resolver
-});
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
 
 loadInitializers(App, config.modulePrefix);
-
-export default App;

--- a/examples/routing/app/controllers/media.js
+++ b/examples/routing/app/controllers/media.js
@@ -1,25 +1,25 @@
-import { computed } from "@ember/object";
-import { equal } from "@ember/object/computed";
 import Controller from "@ember/controller";
+import { tracked } from "@glimmer/tracking";
 
 export default class MediaController extends Controller {
   queryParams = ["filter"];
-  filter = "albums";
+  @tracked filter = "albums";
 
-  @equal("filter", "albums")
-  showAlbums;
+  get showAlbums() {
+    return this.filter === "albums";
+  }
 
-  @equal("filter", "movies")
-  showMovies;
+  get showMovies() {
+    return this.filter === "movies";
+  }
 
-  @computed("showAlbums", "showMovies")
   get media() {
     if (this.showAlbums) {
       return this.model.albums;
     } else if (this.showMovies) {
       return this.model.movies;
-    } else {
-      return [];
     }
+
+    return [];
   }
 }

--- a/examples/routing/app/controllers/media.js
+++ b/examples/routing/app/controllers/media.js
@@ -1,15 +1,19 @@
-import Controller from '@ember/controller';
-import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
+import { computed } from "@ember/object";
+import { equal } from "@ember/object/computed";
+import Controller from "@ember/controller";
 
-export default Controller.extend({
-  queryParams: ['filter'],
-  filter: 'albums',
+export default class MediaController extends Controller {
+  queryParams = ["filter"];
+  filter = "albums";
 
-  showAlbums: equal('filter', 'albums'),
-  showMovies: equal('filter', 'movies'),
+  @equal("filter", "albums")
+  showAlbums;
 
-  media: computed('showAlbums', 'showMovies', function() {
+  @equal("filter", "movies")
+  showMovies;
+
+  @computed("showAlbums", "showMovies")
+  get media() {
     if (this.showAlbums) {
       return this.model.albums;
     } else if (this.showMovies) {
@@ -17,5 +21,5 @@ export default Controller.extend({
     } else {
       return [];
     }
-  })
-});
+  }
+}

--- a/examples/routing/app/router.js
+++ b/examples/routing/app/router.js
@@ -1,17 +1,15 @@
-import EmberRouter from '@ember/routing/router';
-import config from './config/environment';
+import EmberRouter from "@ember/routing/router";
+import config from "routing/config/environment";
 
-const Router = EmberRouter.extend({
-  location: config.locationType,
-  rootURL: config.rootURL
-});
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
 
-Router.map(function() {
-  this.route('media', function() {
-    this.route('medium', { path: '/:medium_id' });
+Router.map(function () {
+  this.route("media", function () {
+    this.route("medium", { path: "/:medium_id" });
   });
-  this.route('fail');
-  this.route('not-found', { path: '*wildcard' });
+  this.route("fail");
+  this.route("not-found", { path: "*wildcard" });
 });
-
-export default Router;

--- a/examples/routing/app/routes/fail.js
+++ b/examples/routing/app/routes/fail.js
@@ -1,14 +1,14 @@
+import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 
-export default Route.extend({
+export default class FailRoute extends Route {
   model() {
     return Promise.reject('an error occured!');
-  },
-
-  actions: {
-    error(e) {
-      //eslint-disable-next-line no-console
-      console.error('Routing error:', e);
-    }
   }
-});
+
+  @action
+  error(e) {
+    //eslint-disable-next-line no-console
+    console.error('Routing error:', e);
+  }
+}

--- a/examples/routing/app/routes/media.js
+++ b/examples/routing/app/routes/media.js
@@ -18,11 +18,11 @@ const MOVIES = [
   { title: "Creed – Rocky’s Legacy" }
 ];
 
-export default Route.extend({
+export default class MediaRoute extends Route {
   model() {
     return hash({
       albums: delayedResponse(ALBUMS),
       movies: delayedResponse(MOVIES)
     });
   }
-});
+}

--- a/examples/routing/app/routes/media/medium.js
+++ b/examples/routing/app/routes/media/medium.js
@@ -1,10 +1,10 @@
-import Route from '@ember/routing/route';
-import delayedResponse from '../../utils/delayed-response';
+import Route from "@ember/routing/route";
+import delayedResponse from "../../utils/delayed-response";
 
-export default Route.extend({
+export default class MediumRoute extends Route {
   model(params) {
     const title = `The individual medium for ID ${params.medium_id}`;
 
     return delayedResponse({ title });
   }
-});
+}

--- a/examples/routing/app/templates/application.hbs
+++ b/examples/routing/app/templates/application.hbs
@@ -1,13 +1,13 @@
 <nav>
   <ul>
     <li>
-      {{link-to "Home" "index"}}
+      <LinkTo @route="index">Home</LinkTo>
     </li>
     <li>
-      {{link-to "Media" "media"}}
+      <LinkTo @route="media">Media</LinkTo>
     </li>
     <li>
-      {{link-to "Error" "fail"}}
+      <LinkTo @route="fail">Error</LinkTo>
     </li>
     <li>
       <a href="/unknown-page">Unknown Page</a>

--- a/examples/routing/app/templates/media.hbs
+++ b/examples/routing/app/templates/media.hbs
@@ -1,12 +1,12 @@
 <h1>Media</h1>
 
-<LinkTo @query={{hash filter="albums"}}>Albums</LinkTo>
-<LinkTo @query={{hash filter="movies"}}>Movies</LinkTo>
+<LinkTo @query={{hash filter="albums"}} class="album-link">Albums</LinkTo>
+<LinkTo @query={{hash filter="movies"}} class="movies-link">Movies</LinkTo>
 
 <ul>
   {{#each this.media as |medium i|}}
     <li>
-      <LinkTo @route="media.medium" @model={{i}}>
+      <LinkTo @route="media.medium" @model={{i}} class="media-link">
         {{medium.title}}
       </LinkTo>
     </li>

--- a/examples/routing/app/templates/media.hbs
+++ b/examples/routing/app/templates/media.hbs
@@ -1,14 +1,14 @@
 <h1>Media</h1>
 
-{{link-to "Albums" (query-params filter="albums")}}
-{{link-to "Movies" (query-params filter="movies")}}
+<LinkTo @query={{hash filter="albums"}}>Albums</LinkTo>
+<LinkTo @query={{hash filter="movies"}}>Movies</LinkTo>
 
 <ul>
-  {{#each media as |medium i|}}
+  {{#each this.media as |medium i|}}
     <li>
-      {{#link-to "media.medium" i}}
+      <LinkTo @route="media.medium" @model={{i}}>
         {{medium.title}}
-      {{/link-to}}
+      </LinkTo>
     </li>
   {{/each}}
 </ul>

--- a/examples/routing/app/templates/media/medium.hbs
+++ b/examples/routing/app/templates/media/medium.hbs
@@ -1,3 +1,3 @@
 <h1>Medium</h1>
 
-<p>{{model.title}}</p>
+<p>{{this.model.title}}</p>

--- a/examples/routing/app/templates/not-found.hbs
+++ b/examples/routing/app/templates/not-found.hbs
@@ -1,3 +1,3 @@
-<h1>Not Found</h1>
+<h1 class="not-found-title">Not Found</h1>
 
-<p>The page you were looking for could not be found.</p>
+<p class="not-found-description" >The page you were looking for could not be found.</p>

--- a/examples/routing/app/utils/delayed-response.js
+++ b/examples/routing/app/utils/delayed-response.js
@@ -1,11 +1,12 @@
-import { later } from '@ember/runloop';
+import { later } from "@ember/runloop";
+import config from "routing/config/environment";
 
-const MIN_DELAY = 1;
-const MAX_DELAY = 3000;
+const { MIN_DELAY, MAX_DELAY } = config;
 
 export default function delayedResponse(response) {
   return new Promise((resolve) => {
-    const delay = Math.floor(Math.random() * (MAX_DELAY - MIN_DELAY)) + MIN_DELAY;
+    const delay =
+      Math.floor(Math.random() * (MAX_DELAY - MIN_DELAY)) + MIN_DELAY;
     later(null, resolve, response, delay);
   });
 }

--- a/examples/routing/config/environment.js
+++ b/examples/routing/config/environment.js
@@ -1,11 +1,13 @@
-'use strict';
+"use strict";
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   let ENV = {
-    modulePrefix: 'routing',
+    modulePrefix: "routing",
     environment,
-    rootURL: '/',
-    locationType: 'auto',
+    rootURL: "/",
+    locationType: "auto",
+    MIN_DELAY: 1,
+    MAX_DELAY: 3000,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -13,17 +15,17 @@ module.exports = function(environment) {
       },
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
-        Date: false
-      }
+        Date: false,
+      },
     },
 
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    }
+    },
   };
 
-  if (environment === 'development') {
+  if (environment === "development") {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -31,19 +33,20 @@ module.exports = function(environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 
-  if (environment === 'test') {
+  if (environment === "test") {
     // Testem prefers this...
-    ENV.locationType = 'none';
+    ENV.locationType = "none";
+    ENV.MAX_DELAY = 1;
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
-    ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.rootElement = "#ember-testing";
     ENV.APP.autoboot = false;
   }
 
-  if (environment === 'production') {
+  if (environment === "production") {
     // here you can enable a production-specific feature
   }
 

--- a/examples/routing/config/optional-features.json
+++ b/examples/routing/config/optional-features.json
@@ -1,3 +1,6 @@
 {
-  "jquery-integration": true
+  "application-template-wrapper": false,
+  "default-async-observers": true,
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
 }

--- a/examples/routing/config/targets.js
+++ b/examples/routing/config/targets.js
@@ -6,7 +6,7 @@ const browsers = [
   'last 1 Safari versions'
 ];
 
-const isCI = !!process.env.CI;
+const isCI = Boolean(process.env.CI);
 const isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {

--- a/examples/routing/package.json
+++ b/examples/routing/package.json
@@ -11,43 +11,50 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build",
+    "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "ember test"
+    "test": "npm-run-all lint:* test:*",
+    "test:ember": "ember test"
   },
   "devDependencies": {
-    "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
+    "@glimmer/component": "^1.0.2",
+    "@glimmer/tracking": "^1.0.2",
+    "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
-    "ember-ajax": "^5.0.0",
+    "ember-auto-import": "^1.6.0",
     "ember-cli": "~3.22.0",
     "ember-cli-app-version": "^4.0.0",
-    "ember-cli-babel": "^7.23.0",
-    "ember-cli-dependency-checker": "^3.1.0",
-    "ember-cli-eslint": "^5.1.0",
+    "ember-cli-babel": "^7.22.1",
+    "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-template-lint": "^1.0.0",
-    "ember-cli-uglify": "^3.0.0",
-    "ember-data": "~3.10.0",
+    "ember-cli-terser": "^4.0.0",
+    "ember-data": "~3.22.0",
     "ember-export-application-global": "^2.0.1",
-    "ember-load-initializers": "^2.1.2",
+    "ember-fetch": "^8.0.2",
+    "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
-    "ember-source": "~3.23.1",
+    "ember-source": "~3.22.0",
+    "ember-template-lint": "^2.14.0",
     "ember-welcome-page": "^4.0.0",
-    "eslint-plugin-ember": "^7.7.2",
+    "eslint": "^7.11.0",
+    "eslint-plugin-ember": "^9.3.0",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
-    "qunit-dom": "^1.6.0"
+    "qunit-dom": "^1.5.0"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "10.* || >= 12"
+  },
+  "ember": {
+    "edition": "octane"
   }
 }

--- a/examples/routing/testem.js
+++ b/examples/routing/testem.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
@@ -7,13 +9,13 @@ module.exports = {
   launch_in_dev: [
     'Chrome'
   ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/examples/routing/tests/acceptance/basic-funtionality-test.js
+++ b/examples/routing/tests/acceptance/basic-funtionality-test.js
@@ -1,0 +1,38 @@
+import { module, test } from "qunit";
+import {
+  click,
+  visit,
+  currentRouteName,
+  currentURL,
+} from "@ember/test-helpers";
+import { setupApplicationTest } from "ember-qunit";
+
+module("Acceptance | basic funtionality", function (hooks) {
+  setupApplicationTest(hooks);
+
+  test("listing and selecting a medium", async function (assert) {
+    await visit("/media");
+    assert.equal(document.querySelectorAll(".media-link").length, 3);
+
+    await click(document.querySelector(".movies-link"));
+    assert.equal(currentURL(), "/media?filter=movies");
+    assert.equal(document.querySelectorAll(".media-link").length, 7);
+
+    await click(document.querySelectorAll(".media-link")[6]);
+    assert.equal(currentURL(), "/media/6?filter=movies");
+  });
+
+  test("shows the not-found route for non existent routes", async function (assert) {
+    await visit("/i-do-not-exist");
+
+    assert.equal(currentRouteName(), "not-found");
+    assert.equal(
+      document.querySelector(".not-found-title").textContent,
+      "Not Found"
+    );
+    assert.equal(
+      document.querySelector(".not-found-description").textContent,
+      "The page you were looking for could not be found."
+    );
+  });
+});

--- a/examples/routing/tests/test-helper.js
+++ b/examples/routing/tests/test-helper.js
@@ -1,5 +1,5 @@
-import Application from '../app';
-import config from '../config/environment';
+import Application from 'routing/app';
+import config from 'routing/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 


### PR DESCRIPTION
I have noticed a bug that is also present in master, if you navigate to media -> movies and then select a movie for a brief moment the query param value seems to revert to the default value, `filter = "albums";` in this case, and then back to the correctly filtered list.

Would like to revisit this once the remaining example repos have been updated.