### PR TITLE
Ci for tomster-player branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - github-actions
+      - tomster-player
   pull_request: {}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - master
       - github-actions
       - tomster-player
+    tags:
+      - step*
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
When we have the steps for the Tomster player in their own branch (see #366) we'll want to run CI for that as well as against each of the tags.