### PR TITLE
fix socket server in web-sockets example

### DIFF
--- a/examples/web-sockets/app/services/messaging.js
+++ b/examples/web-sockets/app/services/messaging.js
@@ -7,7 +7,7 @@ export default class MessagingService extends Service.extend(Evented) {
   @tracked connected = false;
 
   connect() {
-    let socket = io("ws://localhost:3000");
+    let socket = io(window.location.origin);
     socket.on("connect", () => (this.connected = true));
     socket.on("disconnect", () => (this.connected = false));
     socket.on("messaging", (data) => this.trigger("received", data));

--- a/examples/web-sockets/server/index.js
+++ b/examples/web-sockets/server/index.js
@@ -9,7 +9,12 @@
 //   });
 // };
 
-module.exports = function(app) {
+module.exports = function(app, options) {
+  const io = require("socket.io")(options.httpServer, {
+    cors: {},
+  });
+  app.set("io", io);
+
   const globSync = require('glob').sync;
   const mocks    = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
   const proxies  = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);

--- a/examples/web-sockets/server/socket.js
+++ b/examples/web-sockets/server/socket.js
@@ -1,16 +1,5 @@
 module.exports = function (app) {
-  var server = require("http").Server(app);
-  var io = require("socket.io")(server, {
-    cors: {
-      origin: "http://localhost:4200",
-      methods: ["GET", "POST"],
-    },
-  });
-
-  server.listen(3000);
-  // eslint-disable-next-line no-console
-  console.log("Websocket server on http://localhost:3000");
-
+  const io = app.get("io");
   io.on("connection", function (socket) {
     socket.on("messaging", function (data) {
       io.sockets.emit("messaging", data);


### PR DESCRIPTION
This fixes the web-sockets server in the `web-sockets` example so that we don't start up a dedicated server for it anymore but simply attach to the Express server that is running anyway.

addresses #374